### PR TITLE
fix devise user create no method error

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html]
+  config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete


### PR DESCRIPTION
Fix devise Error which was routing to user_path instead of root_path after user creation.

By adding the following:

_config/initializers/devise.rb_
`config.navigational_formats = ['*/*', :html, :turbo_stream]`